### PR TITLE
Adds workaround to compile the project by clang with -Wall -Werror

### DIFF
--- a/include/amqpcpp/array.h
+++ b/include/amqpcpp/array.h
@@ -219,6 +219,7 @@ public:
         stream << ")";
     }
 
+#ifndef AMQPCPP_NO_IMPLICIT_CAST
     /**
      *  Cast to array.
      *
@@ -230,6 +231,8 @@ public:
      *          Yes, clang gets this wrong and gives incorrect warnings here. See
      *          https://llvm.org/bugs/show_bug.cgi?id=28263 for more information
      *
+     *          If you still want to avoid this warning but lose the functionality define AMQPCPP_NO_IMPLICIT_CAST before including amqpcpp.h
+     *
      *  @return Ourselves
      */
     virtual operator const Array& () const override
@@ -237,6 +240,7 @@ public:
         // this already is an array, so no cast is necessary
         return *this;
     }
+#endif
 };
 
 /**

--- a/include/amqpcpp/field.h
+++ b/include/amqpcpp/field.h
@@ -98,8 +98,10 @@ public:
     virtual operator int64_t () const { return 0; }
     virtual operator float () const { return 0; }
     virtual operator double () const { return 0; }
+#ifndef AMQPCPP_NO_IMPLICIT_CAST
     virtual operator const Array& () const;
     virtual operator const Table& () const;
+#endif
 
     /**
      *  Check the field type

--- a/include/amqpcpp/table.h
+++ b/include/amqpcpp/table.h
@@ -253,6 +253,7 @@ public:
         stream << ")";
     }
 
+#ifndef AMQPCPP_NO_IMPLICIT_CAST
     /**
      *  Cast to table.
      *
@@ -264,6 +265,8 @@ public:
      *          Yes, clang gets this wrong and gives incorrect warnings here. See
      *          https://llvm.org/bugs/show_bug.cgi?id=28263 for more information
      *
+     *          If you still want to avoid this warning but lose the functionality define AMQPCPP_NO_IMPLICIT_CAST before including amqpcpp.h
+     *
      *  @return Ourselves
      */
     virtual operator const Table& () const override
@@ -271,6 +274,7 @@ public:
         // this already is a table, so no cast is necessary
         return *this;
     }
+#endif
 };
 
 /**

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -58,6 +58,7 @@ Field::operator const std::string& () const
     return empty;
 }
 
+#ifndef AMQPCPP_NO_IMPLICIT_CAST
 /**
  *  Cast to array
  *  @return Array
@@ -83,6 +84,7 @@ Field::operator const Table& () const
     // return it
     return empty;
 }
+#endif
 
 /**
  *  End of namespace


### PR DESCRIPTION
To build project using clang with -Wall -Werror define AMQPCPP_NO_IMPLICIT_CAST before including amqpcpp header.